### PR TITLE
Generate records with different types of payloads

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ const (
 	RecordCount = "recordCount"
 	ReadTime    = "readTime"
 	Fields      = "fields"
+	Format      = "format"
 )
 
 var knownFieldTypes = []string{"int", "string", "time", "bool"}
@@ -34,6 +35,7 @@ type Config struct {
 	RecordCount int64
 	ReadTime    time.Duration
 	Fields      map[string]string
+	Format      string
 }
 
 func Parse(config map[string]string) (Config, error) {
@@ -54,6 +56,18 @@ func Parse(config map[string]string) (Config, error) {
 		}
 		parsed.ReadTime = readTimeParsed
 	}
+	parsed.Format = "raw"
+	if format, ok := config[Format]; ok {
+		switch format {
+		case "raw", "structured":
+			parsed.Format = format
+		case "":
+			// leave default
+		default:
+			return Config{}, fmt.Errorf("unknown payload format %q", format)
+		}
+	}
+
 	fieldsConcat := config[Fields]
 	if fieldsConcat == "" {
 		return Config{}, errors.New("no fields specified")

--- a/config.go
+++ b/config.go
@@ -27,6 +27,8 @@ const (
 	ReadTime    = "readTime"
 	Fields      = "fields"
 	Format      = "format"
+	Raw         = "raw"
+	Structured  = "structured"
 )
 
 var knownFieldTypes = []string{"int", "string", "time", "bool"}
@@ -56,10 +58,10 @@ func Parse(config map[string]string) (Config, error) {
 		}
 		parsed.ReadTime = readTimeParsed
 	}
-	parsed.Format = "raw"
+	parsed.Format = Raw
 	if format, ok := config[Format]; ok {
 		switch format {
-		case "raw", "structured":
+		case Raw, Structured:
 			parsed.Format = format
 		case "":
 			// leave default

--- a/config_test.go
+++ b/config_test.go
@@ -81,19 +81,19 @@ func TestParseFormat(t *testing.T) {
 			name: "parse 'raw'",
 			input: map[string]string{
 				"fields": "id:int",
-				"format": "raw",
+				"format": Raw,
 			},
 			expErr: "",
-			expVal: "raw",
+			expVal: Raw,
 		},
 		{
 			name: "parse 'structured'",
 			input: map[string]string{
 				"fields": "id:int",
-				"format": "structured",
+				"format": Structured,
 			},
 			expErr: "",
-			expVal: "structured",
+			expVal: Structured,
 		},
 		{
 			name: "default is 'raw' when no value present",
@@ -101,7 +101,7 @@ func TestParseFormat(t *testing.T) {
 				"fields": "id:int",
 			},
 			expErr: "",
-			expVal: "raw",
+			expVal: Raw,
 		},
 		{
 			name: "default is 'raw' when empty string present",
@@ -110,7 +110,7 @@ func TestParseFormat(t *testing.T) {
 				"format": "",
 			},
 			expErr: "",
-			expVal: "raw",
+			expVal: Raw,
 		},
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -69,3 +69,63 @@ func TestParseFields_MalformedFields_NameOnly(t *testing.T) {
 	is.True(err != nil)
 	is.Equal(`invalid field spec "abc"`, err.Error())
 }
+
+func TestParseFormat(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  map[string]string
+		expErr string
+		expVal string
+	}{
+		{
+			name: "parse 'raw'",
+			input: map[string]string{
+				"fields": "id:int",
+				"format": "raw",
+			},
+			expErr: "",
+			expVal: "raw",
+		},
+		{
+			name: "parse 'structured'",
+			input: map[string]string{
+				"fields": "id:int",
+				"format": "structured",
+			},
+			expErr: "",
+			expVal: "structured",
+		},
+		{
+			name: "default is 'raw' when no value present",
+			input: map[string]string{
+				"fields": "id:int",
+			},
+			expErr: "",
+			expVal: "raw",
+		},
+		{
+			name: "default is 'raw' when empty string present",
+			input: map[string]string{
+				"fields": "id:int",
+				"format": "",
+			},
+			expErr: "",
+			expVal: "raw",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			is := is.New(t)
+			parsed, err := Parse(tc.input)
+			if tc.expErr != "" {
+				is.True(err != nil)
+				is.Equal(tc.expErr, err.Error())
+			} else {
+				is.True(err == nil)
+				is.Equal(tc.expVal, parsed.Format)
+			}
+		})
+	}
+}

--- a/source.go
+++ b/source.go
@@ -132,9 +132,9 @@ func (s *Source) newDummyValue(typeString string, i int64) interface{} {
 
 func (s *Source) toData(rec map[string]interface{}) (sdk.Data, error) {
 	switch s.Config.Format {
-	case "raw":
+	case Raw:
 		return s.toRawData(rec)
-	case "structured":
+	case Structured:
 		return sdk.StructuredData(rec), nil
 	default:
 		return nil, fmt.Errorf("unknown format request %q", s.Config.Format)

--- a/source.go
+++ b/source.go
@@ -64,7 +64,7 @@ func (s *Source) Read(ctx context.Context) (sdk.Record, error) {
 		return sdk.Record{}, err
 	}
 
-	data, err := s.toRawData(s.newRecord(s.created))
+	data, err := s.toData(s.newRecord(s.created))
 	if err != nil {
 		return sdk.Record{}, err
 	}
@@ -130,10 +130,21 @@ func (s *Source) newDummyValue(typeString string, i int64) interface{} {
 	}
 }
 
-func (s *Source) toRawData(rec map[string]interface{}) (sdk.Data, error) {
+func (s *Source) toData(rec map[string]interface{}) (sdk.Data, error) {
+	switch s.Config.Format {
+	case "raw":
+		return s.toRawData(rec)
+	case "structured":
+		return sdk.StructuredData(rec), nil
+	default:
+		return nil, fmt.Errorf("unknown format request %q", s.Config.Format)
+	}
+}
+
+func (s *Source) toRawData(rec map[string]interface{}) (sdk.RawData, error) {
 	bytes, err := json.Marshal(rec)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't serialize data: %w", err)
 	}
-	return sdk.RawData(bytes), nil
+	return bytes, nil
 }

--- a/source_test.go
+++ b/source_test.go
@@ -29,14 +29,16 @@ func TestRead_RawData(t *testing.T) {
 	cfg := map[string]string{
 		"recordCount": "1",
 		"fields":      "id:int,name:string,joined:time,admin:bool",
-		"format":      "raw",
+		"format":      Raw,
 	}
 	underTest := NewSource()
 	t.Cleanup(func() {
-		underTest.Teardown(context.Background())
+		_ = underTest.Teardown(context.Background())
 	})
 
-	underTest.Configure(context.Background(), cfg)
+	err := underTest.Configure(context.Background(), cfg)
+	is.NoErr(err)
+
 	rec, err := underTest.Read(context.Background())
 	is.NoErr(err)
 
@@ -49,7 +51,7 @@ func TestRead_RawData(t *testing.T) {
 		joined time.Time
 		admin  bool
 	}{}
-	err = json.Unmarshal(v, &recStruct)
+	err = json.Unmarshal(v, &recStruct) //nolint:staticcheck // test struct
 	is.NoErr(err)
 }
 
@@ -58,14 +60,16 @@ func TestRead_StructuredData(t *testing.T) {
 	cfg := map[string]string{
 		"recordCount": "1",
 		"fields":      "id:int,name:string,joined:time,admin:bool",
-		"format":      "structured",
+		"format":      Structured,
 	}
 	underTest := NewSource()
 	t.Cleanup(func() {
-		underTest.Teardown(context.Background())
+		_ = underTest.Teardown(context.Background())
 	})
 
-	underTest.Configure(context.Background(), cfg)
+	err := underTest.Configure(context.Background(), cfg)
+	is.NoErr(err)
+
 	rec, err := underTest.Read(context.Background())
 	is.NoErr(err)
 
@@ -81,6 +85,6 @@ func TestRead_StructuredData(t *testing.T) {
 	// map to json to struct, so we can check types of all fields easily
 	bytes, err := json.Marshal(v)
 	is.NoErr(err)
-	err = json.Unmarshal(bytes, &recStruct)
+	err = json.Unmarshal(bytes, &recStruct) //nolint:staticcheck // test struct
 	is.NoErr(err)
 }

--- a/source_test.go
+++ b/source_test.go
@@ -1,0 +1,86 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	sdk "github.com/conduitio/conduit-connector-sdk"
+	"github.com/matryer/is"
+)
+
+func TestRead_RawData(t *testing.T) {
+	is := is.New(t)
+	cfg := map[string]string{
+		"recordCount": "1",
+		"fields":      "id:int,name:string,joined:time,admin:bool",
+		"format":      "raw",
+	}
+	underTest := NewSource()
+	t.Cleanup(func() {
+		underTest.Teardown(context.Background())
+	})
+
+	underTest.Configure(context.Background(), cfg)
+	rec, err := underTest.Read(context.Background())
+	is.NoErr(err)
+
+	v, ok := rec.Payload.(sdk.RawData)
+	is.True(ok)
+
+	recStruct := struct {
+		id     int32
+		name   string
+		joined time.Time
+		admin  bool
+	}{}
+	err = json.Unmarshal(v, &recStruct)
+	is.NoErr(err)
+}
+
+func TestRead_StructuredData(t *testing.T) {
+	is := is.New(t)
+	cfg := map[string]string{
+		"recordCount": "1",
+		"fields":      "id:int,name:string,joined:time,admin:bool",
+		"format":      "structured",
+	}
+	underTest := NewSource()
+	t.Cleanup(func() {
+		underTest.Teardown(context.Background())
+	})
+
+	underTest.Configure(context.Background(), cfg)
+	rec, err := underTest.Read(context.Background())
+	is.NoErr(err)
+
+	v, ok := rec.Payload.(sdk.StructuredData)
+	is.True(ok)
+
+	recStruct := struct {
+		id     int32
+		name   string
+		joined time.Time
+		admin  bool
+	}{}
+	// map to json to struct, so we can check types of all fields easily
+	bytes, err := json.Marshal(v)
+	is.NoErr(err)
+	err = json.Unmarshal(bytes, &recStruct)
+	is.NoErr(err)
+}


### PR DESCRIPTION
### Description

This PR makes it possible for the connector to return records with raw or structured payloads. That makes the connector useful in more scenarios.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-generator/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
