### PR TITLE
Add format to specs and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,30 @@
 # Conduit Connector Generator
 
 ### General
-The generator connector is one of [Conduit](https://github.com/ConduitIO/conduit) builtin plugins.
-It generates sample records using its source connector.
-It has no destination and trying to use that will result in an error.
+
+The generator connector is one of [Conduit](https://github.com/ConduitIO/conduit) builtin plugins. It generates sample
+records using its source connector. It has no destination and trying to use that will result in an error.
 
 ### How to build it
+
 Run `make`.
 
 ### Testing
+
 Run `make test` to run all the unit tests.
 
 ### How it works
-The data is generated in JSON format. The JSON objects themselves are generated using a field specification, which is 
+
+The data is generated in JSON format. The JSON objects themselves are generated using a field specification, which is
 explained in more details in the [Configuration section](#Configuration) below.
 
 The connector is great for getting started with Conduit but also for certain types of performance tests.
 
 ### Configuration
+
 | name          | description                                                                                | required | Default |
 |---------------|--------------------------------------------------------------------------------------------|----------|---------|
 | recordCount   | Number of records to be generated. -1 for no limit.                                        | false    | "-1"    |
 | readTime      | The time it takes to 'read' a record.                                                      | false    | "0s"    |
-| fields      | A comma-separated list of name:type tokens, where type can be: int, string, time, bool.    | true     | ""      |
+| fields        | A comma-separated list of name:type tokens, where type can be: int, string, time, bool.    | true     | ""      |
+| format        | Format of the generated payload data: raw, structured.                                     | false    | "raw"   |

--- a/config.go
+++ b/config.go
@@ -27,8 +27,9 @@ const (
 	ReadTime    = "readTime"
 	Fields      = "fields"
 	Format      = "format"
-	Raw         = "raw"
-	Structured  = "structured"
+
+	FormatRaw        = "raw"
+	FormatStructured = "structured"
 )
 
 var knownFieldTypes = []string{"int", "string", "time", "bool"}
@@ -58,16 +59,14 @@ func Parse(config map[string]string) (Config, error) {
 		}
 		parsed.ReadTime = readTimeParsed
 	}
-	parsed.Format = Raw
-	if format, ok := config[Format]; ok {
-		switch format {
-		case Raw, Structured:
-			parsed.Format = format
-		case "":
-			// leave default
-		default:
-			return Config{}, fmt.Errorf("unknown payload format %q", format)
-		}
+	parsed.Format = FormatRaw // default
+	switch config[Format] {
+	case FormatRaw, FormatStructured:
+		parsed.Format = config[Format]
+	case "":
+		// leave default
+	default:
+		return Config{}, fmt.Errorf("unknown payload format %q", config[Format])
 	}
 
 	fieldsConcat := config[Fields]

--- a/config_test.go
+++ b/config_test.go
@@ -81,19 +81,19 @@ func TestParseFormat(t *testing.T) {
 			name: "parse 'raw'",
 			input: map[string]string{
 				"fields": "id:int",
-				"format": Raw,
+				"format": FormatRaw,
 			},
 			expErr: "",
-			expVal: Raw,
+			expVal: FormatRaw,
 		},
 		{
 			name: "parse 'structured'",
 			input: map[string]string{
 				"fields": "id:int",
-				"format": Structured,
+				"format": FormatStructured,
 			},
 			expErr: "",
-			expVal: Structured,
+			expVal: FormatStructured,
 		},
 		{
 			name: "default is 'raw' when no value present",
@@ -101,7 +101,7 @@ func TestParseFormat(t *testing.T) {
 				"fields": "id:int",
 			},
 			expErr: "",
-			expVal: Raw,
+			expVal: FormatRaw,
 		},
 		{
 			name: "default is 'raw' when empty string present",
@@ -110,7 +110,7 @@ func TestParseFormat(t *testing.T) {
 				"format": "",
 			},
 			expErr: "",
-			expVal: Raw,
+			expVal: FormatRaw,
 		},
 	}
 

--- a/source.go
+++ b/source.go
@@ -132,9 +132,9 @@ func (s *Source) newDummyValue(typeString string, i int64) interface{} {
 
 func (s *Source) toData(rec map[string]interface{}) (sdk.Data, error) {
 	switch s.Config.Format {
-	case Raw:
+	case FormatRaw:
 		return s.toRawData(rec)
-	case Structured:
+	case FormatStructured:
 		return sdk.StructuredData(rec), nil
 	default:
 		return nil, fmt.Errorf("unknown format request %q", s.Config.Format)

--- a/source_test.go
+++ b/source_test.go
@@ -29,7 +29,7 @@ func TestRead_RawData(t *testing.T) {
 	cfg := map[string]string{
 		"recordCount": "1",
 		"fields":      "id:int,name:string,joined:time,admin:bool",
-		"format":      Raw,
+		"format":      FormatRaw,
 	}
 	underTest := NewSource()
 	t.Cleanup(func() {
@@ -60,7 +60,7 @@ func TestRead_StructuredData(t *testing.T) {
 	cfg := map[string]string{
 		"recordCount": "1",
 		"fields":      "id:int,name:string,joined:time,admin:bool",
-		"format":      Structured,
+		"format":      FormatStructured,
 	}
 	underTest := NewSource()
 	t.Cleanup(func() {

--- a/spec.go
+++ b/spec.go
@@ -43,6 +43,11 @@ func Specification() sdk.Specification {
 				Required:    true,
 				Description: "A comma-separated list of name:type tokens, where type can be: int, string, time, bool.",
 			},
+			Format: {
+				Default:     FormatRaw,
+				Required:    false,
+				Description: "Format of the generated payload data: raw, structured.",
+			},
 		},
 	}
 }


### PR DESCRIPTION
### Description

This PR adds the field `format` to the specs and to the readme. It also contains a mini refactoring (renames `Raw` and `Structured` to `FormatRaw` and `FormatStructured`).