### PR TITLE
Fix default value for generate time parameter

### DIFF
--- a/source.go
+++ b/source.go
@@ -39,27 +39,36 @@ func NewSource() sdk.Source {
 func (s *Source) Parameters() map[string]sdk.Parameter {
 	return map[string]sdk.Parameter{
 		RecordCount: {
+			Type:        sdk.ParameterTypeInt,
 			Default:     "-1",
 			Description: "Number of records to be generated. -1 for no limit.",
 		},
 		ReadTime: {
+			Type:        sdk.ParameterTypeDuration,
 			Default:     "0s",
 			Description: "The time it takes to 'read' a record.",
 		},
 		SleepTime: {
+			Type:        sdk.ParameterTypeDuration,
 			Default:     "0s",
 			Description: "The time the generator 'sleeps' before it starts generating records. Must be non-negative.",
 		},
 		GenerateTime: {
+			Type:        sdk.ParameterTypeDuration,
 			Default:     "",
 			Description: "The amount of time the generator is generating records. Must be positive. If this option is empty, generator will generate records forever.",
 		},
 		FormatType: {
+			Type:        sdk.ParameterTypeString,
 			Default:     "",
 			Description: "Format of the generated payload data: raw, structured, file.",
-			Validations: []sdk.Validation{sdk.ValidationRequired{}},
+			Validations: []sdk.Validation{
+				sdk.ValidationRequired{},
+				sdk.ValidationInclusion{List: []string{"raw", "structured", "file"}},
+			},
 		},
 		FormatOptions: {
+			Type:    sdk.ParameterTypeString,
 			Default: "",
 			Description: "Options for the format type selected, which are:" +
 				"1. For raw and structured: a comma-separated list of name:type tokens, where type can be: int, string, time, bool." +

--- a/source.go
+++ b/source.go
@@ -40,35 +40,31 @@ func (s *Source) Parameters() map[string]sdk.Parameter {
 	return map[string]sdk.Parameter{
 		RecordCount: {
 			Default:     "-1",
-			Required:    false,
 			Description: "Number of records to be generated. -1 for no limit.",
 		},
 		ReadTime: {
 			Default:     "0s",
-			Required:    false,
 			Description: "The time it takes to 'read' a record.",
 		},
 		SleepTime: {
 			Default:     "0s",
-			Required:    false,
 			Description: "The time the generator 'sleeps' before it starts generating records. Must be non-negative.",
 		},
 		GenerateTime: {
-			Default:     "max. duration in Go",
-			Required:    false,
-			Description: "The amount of time the generator is generating records. Must be positive.",
+			Default:     "",
+			Description: "The amount of time the generator is generating records. Must be positive. If this option is empty, generator will generate records forever.",
 		},
 		FormatType: {
 			Default:     "",
-			Required:    true,
 			Description: "Format of the generated payload data: raw, structured, file.",
+			Validations: []sdk.Validation{sdk.ValidationRequired{}},
 		},
 		FormatOptions: {
-			Default:  "",
-			Required: true,
+			Default: "",
 			Description: "Options for the format type selected, which are:" +
 				"1. For raw and structured: a comma-separated list of name:type tokens, where type can be: int, string, time, bool." +
 				"2. For the file format: a path to the file.",
+			Validations: []sdk.Validation{sdk.ValidationRequired{}},
 		},
 	}
 }


### PR DESCRIPTION
### Description

The default value for `burst.generateTime` had an invalid value. The SDK now sets the default value automatically if the user did not provide a value, so this meant that empty values were invalid.