### PR TITLE
Update connector.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ pipelines:
           collections.orders.format.options.id: int
           collections.orders.format.options.product: string
           collections.orders.operations: create,update,delete
-```<!-- /readmegen:description -->
+```
+<!-- /readmegen:description -->
 
 ## Configuration
 

--- a/connector.yaml
+++ b/connector.yaml
@@ -2,7 +2,7 @@ version: "1.0"
 specification:
   name: generator
   summary: A plugin capable of generating dummy records (in different formats).
-  description: |-
+  description: |
     The generator is capable of generating dummy records (in JSON format). The
     connector makes it possible to configure the records' fields, the operation
     (whether the record was created, updated or deleted), the rate at which records


### PR DESCRIPTION
### Description

End triple backtick breaks readmegen, resulting in this:

![image](https://github.com/user-attachments/assets/c9a3c200-8200-4fe0-a743-9fdf5e123442)

Just removing the `-` works. Also, thankfully specgen does not override that change, so it's safe to delete.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-generator/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
